### PR TITLE
Preparing for initial release

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - publishUpdates
   release:
     types: [created]
 

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
       - main
+      - publishUpdates
+  release:
+    types: [created]
 
 jobs:
   build:
@@ -23,6 +26,6 @@ jobs:
         settings-path: ${{ github.workspace }} # location for the settings.xml file
 
     - name: Publish to GitHub Packages Apache Maven
-      run: mvn -B clean deploy -s $GITHUB_WORKSPACE/settings.xml -D-Drevision=0.0.1-SNAPSHOT -f service-base-utils-parent-os
+      run: mvn -B clean deploy -s $GITHUB_WORKSPACE/settings.xml -f service-base-utils-parent-os
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/service-base-utils-parent-os/pom.xml
+++ b/service-base-utils-parent-os/pom.xml
@@ -30,8 +30,8 @@
 	</modules>
 
 	<properties>
-		<base-version>0.0.1</base-version>
-		<revision>${base-version}-SNAPSHOT</revision>
+		<base-version>1.0.0</base-version>
+		<revision>${base-version}</revision>
 	
 		<whCompanyName>IBM Corp</whCompanyName>
 		<whprojectGitRepo>REST-service-framework</whprojectGitRepo>


### PR DESCRIPTION
My plan is to merge this to main, create a tag, immediately bump the bugfix version and add -SNAPSHOT back.

I confirmed that maven deploy is using the version from the POM and does not need to be specified.